### PR TITLE
Revert test options

### DIFF
--- a/.github/scripts/ci-test.sh
+++ b/.github/scripts/ci-test.sh
@@ -21,8 +21,7 @@ python scripts/testMMTk.py -j $JAVA_HOME -g RBaseBaseSemiSpace -a "Xms75M Xmx75M
 ./dist/RFastAdaptiveNoGC_x86_64-linux/rvm -Xms3G -Xmx3G -jar benchmarks/dacapo-2006-10-MR2.jar luindex
 ./dist/RFastAdaptiveNoGC_x86_64-linux/rvm -Xms3G -Xmx3G -jar benchmarks/dacapo-2006-10-MR2.jar pmd
 
-# Running the GC tests with recompilation disabled. See https://github.com/mmtk/mmtk-jikesrvm/issues/36
-RVM_OPTIONS='-X:aos:initial_compiler=opt -X:aos:enable_recompilation=false'
+RVM_OPTIONS='-X:gc:threads=16'
 
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=../../ --use-third-party-build-configs=../../jikesrvm/build/configs --use-external-source=../../jikesrvm/rvm/src


### PR DESCRIPTION
We are still seeing JikesRVM stuck with recompilation disabled. This PR reverts back the changes in https://github.com/mmtk/mmtk-jikesrvm/pull/43. We will expect to see indeterministic deadlock again. 

I am still looking to figure out the bug. 