### PR TITLE
Update OOM API.

### DIFF
--- a/.github/workflows/ci-assert.yml
+++ b/.github/workflows/ci-assert.yml
@@ -12,12 +12,10 @@ jobs:
       # Checkout repos and submodules
       - uses: actions/checkout@v2
         with:
-          # CI_ACCESS_TOKEN is a secret set with the repo
-          token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
 
       - name: Setup Rust Toolchain
-        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk/rust-toolchain`" >> $GITHUB_ENV        
+        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk/rust-toolchain`" >> $GITHUB_ENV
       - name: Setup Environments
         run: ./.github/scripts/ci-setup.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,10 @@ jobs:
       # Checkout repos and submodules
       - uses: actions/checkout@v2
         with:
-          # CI_ACCESS_TOKEN is a secret set with the repo
-          token: ${{ secrets.CI_ACCESS_TOKEN }}
           submodules: true
 
       - name: Setup Rust Toolchain
-        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk/rust-toolchain`" >> $GITHUB_ENV        
+        run: echo "RUSTUP_TOOLCHAIN=`cat mmtk/rust-toolchain`" >> $GITHUB_ENV
       - name: Setup Environments
         run: ./.github/scripts/ci-setup.sh
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -21,7 +21,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/k-sareen/mmtk-core.git", rev = "2b41f0160f84a52c2338a9c0809ee651ecf7d899" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "c38365be73e83dfd8a41e901d4537e87e0eb0ffe" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -21,7 +21,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "4ebb6b68f54a55bf8794ea01db3f2d0f28d15f4d" }
+mmtk = { git = "https://github.com/k-sareen/mmtk-core.git", rev = "e1812cb0d407c901069f7a24da5c0fc340a5b5e4" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -1,6 +1,6 @@
 use entrypoint::*;
 use mmtk::scheduler::*;
-use mmtk::util::alloc::MmtkAllocationError;
+use mmtk::util::alloc::AllocationError;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::Address;
 use mmtk::vm::Collection;
@@ -62,7 +62,7 @@ impl Collection<JikesRVM> for VMCollection {
         }
     }
 
-    fn out_of_memory(tls: VMThread, _err_kind: MmtkAllocationError) {
+    fn out_of_memory(tls: VMThread, _err_kind: AllocationError) {
         unsafe {
             jtoc_call!(OUT_OF_MEMORY_METHOD_OFFSET, tls);
         }

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -1,5 +1,6 @@
 use entrypoint::*;
 use mmtk::scheduler::*;
+use mmtk::util::alloc::MmtkAllocationError;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::Address;
 use mmtk::vm::Collection;
@@ -61,7 +62,7 @@ impl Collection<JikesRVM> for VMCollection {
         }
     }
 
-    fn out_of_memory(tls: VMThread) {
+    fn out_of_memory(tls: VMThread, _err_kind: MmtkAllocationError) {
         unsafe {
             jtoc_call!(OUT_OF_MEMORY_METHOD_OFFSET, tls);
         }


### PR DESCRIPTION
Note that JikesRVM will abort the VM immediately when an OOM is
reported. Hence, we do not have to account for the case where MMTk core
has returned a `null` pointer back to the VM due to OOM.

JikesRVM also makes no distinction between an OOM due to the OS being
unable to acquire more memory and a simple Java Heap OOM.

Associated mmtk-core PR: https://github.com/mmtk/mmtk-core/pull/535