### PR TITLE
Remove use of TraceLocal

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "e0273429f5239ab03407b4a93b52b21f45930d88" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "6410f0a85e9289288d89a96e9f5ba157243c8a93" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/src/scan_sanity.rs
+++ b/mmtk/src/scan_sanity.rs
@@ -1,9 +1,8 @@
 use entrypoint::*;
 use mmtk::util::OpaquePointer;
-use mmtk::TraceLocal;
 use std::arch::asm;
 
-pub fn scan_boot_image_sanity<T: TraceLocal>(_trace: &mut T, tls: OpaquePointer) {
+pub fn scan_boot_image_sanity(tls: OpaquePointer) {
     trace!("scan_boot_image_sanity");
     let boot_image_roots: [usize; 10000] = [0; 10000];
     let addr = &boot_image_roots as *const usize;


### PR DESCRIPTION
This PR removes the use of `TraceLocal` in the binding.