### PR TITLE
Set MMTk thread names for debugging.

### DIFF
--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -90,6 +90,11 @@ pub extern "C" fn start_control_collector(
     gc_controller: *mut GCController<JikesRVM>,
 ) {
     let mut gc_controller = unsafe { Box::from_raw(gc_controller) };
+    let cstr = std::ffi::CString::new("MMTkController").unwrap();
+    unsafe {
+        libc::pthread_setname_np(libc::pthread_self(), cstr.as_ptr());
+    }
+
     memory_manager::start_control_collector(&SINGLETON, tls, &mut gc_controller);
 }
 
@@ -98,6 +103,10 @@ pub extern "C" fn start_control_collector(
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn start_worker(tls: VMWorkerThread, worker: *mut GCWorker<JikesRVM>) {
     let mut worker = unsafe { Box::from_raw(worker) };
+    let cstr = std::ffi::CString::new(format!("MMTkWorker{}", worker.ordinal)).unwrap();
+    unsafe {
+        libc::pthread_setname_np(libc::pthread_self(), cstr.as_ptr());
+    }
     memory_manager::start_worker::<JikesRVM>(&SINGLETON, tls, &mut worker)
 }
 


### PR DESCRIPTION
Set the name of MMTk threads so when debugging with GDB, it will show
their names, such as "MMTkController" and "MMTkWorker1".  It will make
it easier to tell which thread is having problem.

When shown in GDB, it looks like this:

```
(gdb) info threads
  Id   Target Id                                      Frame 
* 1    Thread 0xf79ee980 (LWP 13471) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  2    Thread 0xf77acac0 (LWP 13483) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  3    Thread 0xf6fabac0 (LWP 13484) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  4    Thread 0xf63ffac0 (LWP 13485) "MMTkController" 0xf7ef8549 in __kernel_vsyscall ()
  5    Thread 0xf5bfeac0 (LWP 13486) "MMTkWorker0"    0xf7dd2892 in ?? ()
  6    Thread 0xf53fdac0 (LWP 13487) "MMTkWorker1"    0xf7d7743a in ?? ()
  7    Thread 0xf47ffac0 (LWP 13488) "MMTkWorker2"    0xf7d76f3c in ?? ()
  8    Thread 0xf3ffeac0 (LWP 13489) "MMTkWorker3"    0xf7d77364 in ?? ()
  9    Thread 0xf37fdac0 (LWP 13490) "MMTkWorker4"    0xf7d7742c in ?? ()
  10   Thread 0xf2dfcac0 (LWP 13491) "MMTkWorker5"    0xf7d77364 in ?? ()
  11   Thread 0xf25fbac0 (LWP 13492) "MMTkWorker6"    0xf7dc3abc in ?? ()
  12   Thread 0xf1bffac0 (LWP 13493) "MMTkWorker7"    0xf7d77364 in ?? ()
  13   Thread 0xf13feac0 (LWP 13494) "MMTkWorker8"    0xf7d77364 in ?? ()
  14   Thread 0xf09ffac0 (LWP 13495) "MMTkWorker9"    0xf7ef8549 in __kernel_vsyscall ()
  15   Thread 0xefdffac0 (LWP 13496) "MMTkWorker10"   0xf7d77074 in ?? ()
  16   Thread 0xef5feac0 (LWP 13497) "MMTkWorker11"   0xf7ef8549 in __kernel_vsyscall ()
  17   Thread 0xee8ffac0 (LWP 13498) "MMTkWorker12"   0xf7d77364 in ?? ()
  18   Thread 0xee0feac0 (LWP 13499) "MMTkWorker13"   0xf7d7701b in ?? ()
  19   Thread 0xed6ffac0 (LWP 13500) "MMTkWorker14"   0xf7d76ef8 in ?? ()
  20   Thread 0xeccffac0 (LWP 13501) "MMTkWorker15"   0xf7d7729c in ?? ()
  21   Thread 0xec0ffac0 (LWP 13502) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  22   Thread 0xeb8feac0 (LWP 13503) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  23   Thread 0xeb0fdac0 (LWP 13504) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  24   Thread 0xea4ffac0 (LWP 13505) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  25   Thread 0xe9cfeac0 (LWP 13506) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  26   Thread 0xe94fdac0 (LWP 13507) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
  27   Thread 0xe8cfcac0 (LWP 13508) "JikesRVM"       0xf7ef8549 in __kernel_vsyscall ()
```