### PR TITLE
Use large code and non moving semantics.

### DIFF
--- a/jikesrvm/rvm/src/org/jikesrvm/mm/mminterface/MMTkAllocator.java
+++ b/jikesrvm/rvm/src/org/jikesrvm/mm/mminterface/MMTkAllocator.java
@@ -7,4 +7,6 @@ public class MMTkAllocator {
     public static final int LOS = 2;
     public static final int CODE = 3;
     public static final int READONLY = 4;
+    public static final int LARGE_CODE = 5;
+    public static final int NONMOVING = 6;
 }

--- a/jikesrvm/rvm/src/org/jikesrvm/mm/mminterface/MMTkMutatorContext.java
+++ b/jikesrvm/rvm/src/org/jikesrvm/mm/mminterface/MMTkMutatorContext.java
@@ -290,8 +290,12 @@ public abstract class MMTkMutatorContext extends MutatorContext {
             return MMTkAllocator.IMMORTAL;
         else if (origAllocator == Plan.ALLOC_LOS)
             return MMTkAllocator.LOS;
-        else if (origAllocator == Plan.ALLOC_CODE || origAllocator == Plan.ALLOC_LARGE_CODE)
+        else if (origAllocator == Plan.ALLOC_CODE)
             return MMTkAllocator.CODE;
+        else if (origAllocator == Plan.ALLOC_LARGE_CODE)
+            return MMTkAllocator.LARGE_CODE;
+        else if (origAllocator == Plan.ALLOC_NON_MOVING)
+            return MMTkAllocator.NONMOVING;
         else {
             return MMTkAllocator.IMMORTAL;
         }

--- a/jikesrvm/rvm/src/org/jikesrvm/mm/mminterface/MSContext.java
+++ b/jikesrvm/rvm/src/org/jikesrvm/mm/mminterface/MSContext.java
@@ -14,11 +14,15 @@ package org.jikesrvm.mm.mminterface;
 
 import org.vmmagic.pragma.*;
 import org.vmmagic.unboxed.*;
+import org.jikesrvm.VM;
 
 @Uninterruptible
 public class MSContext extends MMTkMutatorContext {
-    // DEFAULT: MallocAllocator #0 (MS)
-    // CODE/READONLY: BumpAllocator #0 (ImmortalSpace)
+    // DEFAULT: MallocAllocator #0 (MallocSpace)
+    // CODE: BumpAllocator #0 (ImmortalSpace)
+    // LARGECODE: BumpAllocator #1 (ImmortalSpace)
+    // Immortal: BumpAllocator #2 (ImmortalSpace)
+    // NonMomving: BumpAllocator #3 (ImmortalSpace)
     // LOS: LargeObjectAllocator #0 (LargeObjectSpace)
 
     @Inline
@@ -31,7 +35,18 @@ public class MSContext extends MMTkMutatorContext {
     }
     @Inline
     protected final int getAllocatorIndex(int allocator) {
-        return 0;
+        if (allocator == MMTkAllocator.DEFAULT || allocator == MMTkAllocator.CODE || allocator == MMTkAllocator.LOS) {
+            return 0;
+        } else if (allocator == MMTkAllocator.LARGE_CODE) {
+            return 1;
+        } else if (allocator == MMTkAllocator.IMMORTAL) {
+            return 2;
+        } else if (allocator == MMTkAllocator.NONMOVING) {
+            return 3;
+        } else {
+            VM.sysFail("Unexpected allocator", allocator);
+            return 0;
+        }
     }
     @Inline
     protected final int getSpaceTag(int allocator) {

--- a/jikesrvm/rvm/src/org/jikesrvm/mm/mminterface/SSContext.java
+++ b/jikesrvm/rvm/src/org/jikesrvm/mm/mminterface/SSContext.java
@@ -14,11 +14,15 @@ package org.jikesrvm.mm.mminterface;
 
 import org.vmmagic.pragma.*;
 import org.vmmagic.unboxed.*;
+import org.jikesrvm.VM;
 
 @Uninterruptible
 public class SSContext extends MMTkMutatorContext {
     // DEFAULT: BumpAllocator #0 (CopySpace)
-    // CODE/READONLY: BumpAllocator #1 (ImmortalSpace)
+    // CODE: BumpAllocator #1 (ImmortalSpace)
+    // LARGE_CODE: BumpAllocator #2 (ImmortalSpace)
+    // Immortal: BumpAllocator #3 (ImmortalSpace)
+    // NonMoving: BumpAllocator #4 (ImmortalSpace)
     // LOS: LargeObjectAllocator #0 (LargeObjectSpace)
 
     @Inline
@@ -31,11 +35,18 @@ public class SSContext extends MMTkMutatorContext {
     }
     @Inline
     protected final int getAllocatorIndex(int allocator) {
-        if (allocator == MMTkAllocator.DEFAULT) {
+        if (allocator == MMTkAllocator.DEFAULT || allocator == MMTkAllocator.LOS) {
             return 0;
-        } else if (allocator == MMTkAllocator.IMMORTAL || allocator == MMTkAllocator.CODE || allocator == MMTkAllocator.READONLY) {
+        } else if (allocator == MMTkAllocator.CODE) {
             return 1;
+        } else if (allocator == MMTkAllocator.LARGE_CODE) {
+            return 2;
+        } else if (allocator == MMTkAllocator.IMMORTAL) {
+            return 3;
+        } else if (allocator == MMTkAllocator.NONMOVING) {
+            return 4;
         } else {
+            VM.sysFail("Unexpected allocator", allocator);
             return 0;
         }
     }

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.15.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb#b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=129fc0e14df6eb26a4cf82d28b8f0a1f429a2614#129fc0e14df6eb26a4cf82d28b8f0a1f429a2614"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.15.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb#b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=129fc0e14df6eb26a4cf82d28b8f0a1f429a2614#129fc0e14df6eb26a4cf82d28b8f0a1f429a2614"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.15.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=129fc0e14df6eb26a4cf82d28b8f0a1f429a2614#129fc0e14df6eb26a4cf82d28b8f0a1f429a2614"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=53b6d57c2a96f6064e01e245ea0be05dd673cfad#53b6d57c2a96f6064e01e245ea0be05dd673cfad"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.15.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=129fc0e14df6eb26a4cf82d28b8f0a1f429a2614#129fc0e14df6eb26a4cf82d28b8f0a1f429a2614"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=53b6d57c2a96f6064e01e245ea0be05dd673cfad#53b6d57c2a96f6064e01e245ea0be05dd673cfad"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.15.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=f82848847a6392537fec6b914d7ad95fbf28b0a2#f82848847a6392537fec6b914d7ad95fbf28b0a2"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb#b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.15.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=f82848847a6392537fec6b914d7ad95fbf28b0a2#f82848847a6392537fec6b914d7ad95fbf28b0a2"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb#b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "129fc0e14df6eb26a4cf82d28b8f0a1f429a2614" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "53b6d57c2a96f6064e01e245ea0be05dd673cfad" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "129fc0e14df6eb26a4cf82d28b8f0a1f429a2614" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "f82848847a6392537fec6b914d7ad95fbf28b0a2" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "b68b9cd0ab41ccd0d4073d9933d7da61f88f6eeb" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 


### PR DESCRIPTION
This PR adds large code and non moving allocation semantics, and properly uses the semantics in picking allocators. This PR also fixes the alloator/space mapping in our allocator fastpath to make it up-to-date with mmtk-core.