### PR TITLE
Refactor finalize/reference processor

### DIFF
--- a/.github/scripts/ci-test-assertions-use-bind-ref-proc.sh
+++ b/.github/scripts/ci-test-assertions-use-bind-ref-proc.sh
@@ -7,10 +7,10 @@ cd $JIKESRVM_PATH
 
 # RBaseBaseSemiSpaceAssertions
 ./bin/buildit localhost RBaseBaseSemiSpaceAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 
 # RBaseBaseMarkSweepAssertions
 ./bin/buildit localhost RBaseBaseMarkSweepAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex

--- a/.github/scripts/ci-test-assertions.sh
+++ b/.github/scripts/ci-test-assertions.sh
@@ -7,10 +7,10 @@ cd $JIKESRVM_PATH
 
 # RBaseBaseSemiSpaceAssertions
 ./bin/buildit localhost RBaseBaseSemiSpaceAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx450M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 
 # RBaseBaseMarkSweepAssertions
 ./bin/buildit localhost RBaseBaseMarkSweepAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
 ./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx450M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex

--- a/.github/scripts/ci-test-assertions.sh
+++ b/.github/scripts/ci-test-assertions.sh
@@ -7,10 +7,10 @@ cd $JIKESRVM_PATH
 
 # RBaseBaseSemiSpaceAssertions
 ./bin/buildit localhost RBaseBaseSemiSpaceAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx450M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 
 # RBaseBaseMarkSweepAssertions
 ./bin/buildit localhost RBaseBaseMarkSweepAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx450M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex

--- a/.github/scripts/ci-test-normal-use-bind-ref-proc.sh
+++ b/.github/scripts/ci-test-normal-use-bind-ref-proc.sh
@@ -1,0 +1,68 @@
+set -xe
+
+. $(dirname "$0")/common.sh
+
+# To JikesRVM folder
+cd $JIKESRVM_PATH
+
+# Directory containing properties files
+PROPERTIES_DIR="$BINDING_PATH/jikesrvm/build/configs"
+
+# Find all .properties files and update them using sed
+find "$PROPERTIES_DIR" -type f -name "*.properties" -exec sed -i 's/rust.binding_side_ref_proc=false/rust.binding_side_ref_proc=true/' {} \;
+
+
+# Test BaseBase builds
+# Only run one test
+
+# RBaseBaseNoGC
+./bin/buildit localhost RBaseBaseNoGC -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1224M -Xms1224M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+# RBaseBaseSemiSpace
+./bin/buildit localhost RBaseBaseSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx400M -Xms400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+
+# Test FastAdaptive builds
+# Run all possible dacapo benchmarks
+
+# RFastAdaptiveNoGC (use largest heap possible)
+./bin/buildit localhost RFastAdaptiveNoGC -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+
+export MMTK_THREADS=16
+
+# RFastAdaptiveSemiSpace
+./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms2000M -Xmx2000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1500M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+
+# RFastAdaptiveMarkSweep
+./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+
+# Flaky test: Failing instruction starting at xxxxx wasn't in RVM address space
+# see https://github.com/mmtk/mmtk-jikesrvm/issues/108
+#./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+
+# Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
+#./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1100M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms800M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+
+find "$PROPERTIES_DIR" -type f -name "*.properties" -exec sed -i 's/rust.binding_side_ref_proc=true/rust.binding_side_ref_proc=false/' {} \;

--- a/.github/scripts/ci-test-normal.sh
+++ b/.github/scripts/ci-test-normal.sh
@@ -10,10 +10,10 @@ cd $JIKESRVM_PATH
 
 # RBaseBaseNoGC
 ./bin/buildit localhost RBaseBaseNoGC -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1024M -Xms1024M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1224M -Xms1024M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 # RBaseBaseSemiSpace
 ./bin/buildit localhost RBaseBaseSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx200M -Xms75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx400M -Xms75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 
 # Test FastAdaptive builds
 # Run all possible dacapo benchmarks
@@ -29,27 +29,27 @@ export MMTK_THREADS=16
 
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 #fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 #fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx2000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 #fail./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
 #./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 #fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx450M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 #fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan

--- a/.github/scripts/ci-test-normal.sh
+++ b/.github/scripts/ci-test-normal.sh
@@ -10,10 +10,10 @@ cd $JIKESRVM_PATH
 
 # RBaseBaseNoGC
 ./bin/buildit localhost RBaseBaseNoGC -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1224M -Xms1024M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1024M -Xms1024M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 # RBaseBaseSemiSpace
 ./bin/buildit localhost RBaseBaseSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx400M -Xms75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx75M -Xms75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 
 # Test FastAdaptive builds
 # Run all possible dacapo benchmarks
@@ -29,31 +29,27 @@ export MMTK_THREADS=16
 
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx2000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-#fail./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-
-# Flaky test: Failing instruction starting at xxxxx wasn't in RVM address space
-# see https://github.com/mmtk/mmtk-jikesrvm/issues/108
-#./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
 #./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-#fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-#fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan

--- a/.github/scripts/ci-test-normal.sh
+++ b/.github/scripts/ci-test-normal.sh
@@ -37,13 +37,17 @@ export MMTK_THREADS=16
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx2000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 #fail./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
 ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+
+# Flaky test: Failing instruction starting at xxxxx wasn't in RVM address space
+# see https://github.com/mmtk/mmtk-jikesrvm/issues/108
+#./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
 #./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
 ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop

--- a/.github/scripts/ci-test-normal.sh
+++ b/.github/scripts/ci-test-normal.sh
@@ -13,7 +13,7 @@ cd $JIKESRVM_PATH
 ./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1024M -Xms1024M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 # RBaseBaseSemiSpace
 ./bin/buildit localhost RBaseBaseSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx75M -Xms75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx200M -Xms75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 
 # Test FastAdaptive builds
 # Run all possible dacapo benchmarks
@@ -29,27 +29,27 @@ export MMTK_THREADS=16
 
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
 #./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
 ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+#fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx450M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan

--- a/.github/scripts/ci-test-weak-ref-use-bind-ref-proc.sh
+++ b/.github/scripts/ci-test-weak-ref-use-bind-ref-proc.sh
@@ -1,0 +1,54 @@
+set -xe
+
+. $(dirname "$0")/common.sh
+
+# To JikesRVM folder
+cd $JIKESRVM_PATH
+
+# Test FastAdaptive builds
+# Run all possible Dacapo benchmarks
+
+export MMTK_THREADS=16
+export RUST_BACKTRACE=1
+RVM_OPTIONS=-X:gc:no_reference_types=false
+
+# Directory containing properties files
+PROPERTIES_DIR="$BINDING_PATH/jikesrvm/build/configs"
+
+# Find all .properties files and update them using sed
+find "$PROPERTIES_DIR" -type f -name "*.properties" -exec sed -i 's/rust.binding_side_ref_proc=false/rust.binding_side_ref_proc=true/' {} \;
+
+
+# RFastAdaptiveSemiSpace
+./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms2G -Xmx2G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1500M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1800M -Xmx1800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+
+# RFastAdaptiveMarkSweep
+./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+
+# Flaky test: Failing instruction starting at xxxxx wasn't in RVM address space
+# see https://github.com/mmtk/mmtk-jikesrvm/issues/108
+# ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+
+# Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
+# ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1100M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms800M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms950M -Xmx950M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+
+# Find all .properties files and update them using sed
+find "$PROPERTIES_DIR" -type f -name "*.properties" -exec sed -i 's/rust.binding_side_ref_proc=true/rust.binding_side_ref_proc=false/' {} \;

--- a/.github/scripts/ci-test-weak-ref.sh
+++ b/.github/scripts/ci-test-weak-ref.sh
@@ -15,26 +15,26 @@ RVM_OPTIONS=-X:gc:no_reference_types=false
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
 #fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
 #fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 #fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
 #fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
 # ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 #fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 #fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx950M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan

--- a/.github/scripts/ci-test-weak-ref.sh
+++ b/.github/scripts/ci-test-weak-ref.sh
@@ -6,7 +6,7 @@ set -xe
 cd $JIKESRVM_PATH
 
 # Test FastAdaptive builds
-# Run all possible dacapo benchmarks
+# Run all possible Dacapo benchmarks
 
 export MMTK_THREADS=16
 export RUST_BACKTRACE=1
@@ -16,19 +16,23 @@ RVM_OPTIONS=-X:gc:no_reference_types=false
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
 #fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx2G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 #fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
 ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+
+# Flaky test: Failing instruction starting at xxxxx wasn't in RVM address space
+# see https://github.com/mmtk/mmtk-jikesrvm/issues/108
+# ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
 # ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
 ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop

--- a/.github/scripts/ci-test-weak-ref.sh
+++ b/.github/scripts/ci-test-weak-ref.sh
@@ -6,39 +6,34 @@ set -xe
 cd $JIKESRVM_PATH
 
 # Test FastAdaptive builds
-# Run all possible Dacapo benchmarks
+# Run all possible dacapo benchmarks
 
 export MMTK_THREADS=16
-export RUST_BACKTRACE=1
 RVM_OPTIONS=-X:gc:no_reference_types=false
 
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx2G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-
-# Flaky test: Failing instruction starting at xxxxx wasn't in RVM address space
-# see https://github.com/mmtk/mmtk-jikesrvm/issues/108
-# ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
-# ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-#fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-#fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx950M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+#./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan

--- a/.github/scripts/ci-test-weak-ref.sh
+++ b/.github/scripts/ci-test-weak-ref.sh
@@ -9,31 +9,32 @@ cd $JIKESRVM_PATH
 # Run all possible dacapo benchmarks
 
 export MMTK_THREADS=16
+export RUST_BACKTRACE=1
 RVM_OPTIONS=-X:gc:no_reference_types=false
 
 # RFastAdaptiveSemiSpace
-./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+# ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
-#./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+# ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+# ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx4000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+# ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan

--- a/.github/scripts/ci-test-weak-ref.sh
+++ b/.github/scripts/ci-test-weak-ref.sh
@@ -13,28 +13,28 @@ export RUST_BACKTRACE=1
 RVM_OPTIONS=-X:gc:no_reference_types=false
 
 # RFastAdaptiveSemiSpace
-# ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-# ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx1700M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
 # ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-# ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx4000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-# ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx750M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan

--- a/build.xml
+++ b/build.xml
@@ -3,6 +3,7 @@
     <property name="rvm-binding.source" location="${config.third-party-heap}/jikesrvm/rvm"/>
     <property name="rvm-binding.tools" location="${config.third-party-heap}/jikesrvm/tools"/>
     <property name="mmtk-binding.dir" location="${config.third-party-heap}/mmtk"/>
+    <property name="rust.binding_side_ref_proc" value="false"/>
     <property environment="env"/>
 
     <!-- Generate a few files that will be used by Rust mmtk -->
@@ -46,6 +47,11 @@
         <exec executable="/usr/bin/as" failonerror="true">
             <arg line="--32 -o ${build.base}/${target.obj-prefix}glue${target.obj-ext} -I ${mmtk-binding.dir}/src ${mmtk-binding.dir}/src/glue.asm"/>
         </exec>
+        <!-- When rust.binding_side_ref_proc is true, binding_side_ref_proc will be appended to the features.
+        If it’s false, the features will remain unchanged. -->
+        <condition property="rust.features" value="${rust.features},binding_side_ref_proc">
+            <equals arg1="${rust.binding_side_ref_proc}" arg2="true"/>
+        </condition>
         <exec executable="cargo" dir="${mmtk-binding.dir}" failonerror="true">
             <arg value="rustc"/>
             <arg value="--manifest-path=${mmtk-binding.dir}/Cargo.toml"/>

--- a/jikesrvm/build/configs/RBaseBaseMarkSweep.properties
+++ b/jikesrvm/build/configs/RBaseBaseMarkSweep.properties
@@ -13,6 +13,7 @@
 config.mmtk.plan=org.mmtk.plan.marksweep.MS
 plan.name=MS
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RBaseBaseMarkSweepAssertions.properties
+++ b/jikesrvm/build/configs/RBaseBaseMarkSweepAssertions.properties
@@ -13,6 +13,7 @@
 config.mmtk.plan=org.mmtk.plan.marksweep.MS
 plan.name=MS
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RBaseBaseNoGC.properties
+++ b/jikesrvm/build/configs/RBaseBaseNoGC.properties
@@ -13,6 +13,7 @@
 config.mmtk.plan=org.mmtk.plan.nogc.NoGC
 plan.name=NoGC
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RBaseBaseNoGCRelease.properties
+++ b/jikesrvm/build/configs/RBaseBaseNoGCRelease.properties
@@ -13,6 +13,7 @@
 config.mmtk.plan=org.mmtk.plan.nogc.NoGC
 plan.name=NoGC
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RBaseBaseSemiSpace.properties
+++ b/jikesrvm/build/configs/RBaseBaseSemiSpace.properties
@@ -13,6 +13,7 @@
 config.mmtk.plan=org.mmtk.plan.semispace.SS
 plan.name=SS
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RBaseBaseSemiSpaceAssertions.properties
+++ b/jikesrvm/build/configs/RBaseBaseSemiSpaceAssertions.properties
@@ -13,6 +13,7 @@
 config.mmtk.plan=org.mmtk.plan.semispace.SS
 plan.name=SS
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RBaseBaseSemiSpaceRelease.properties
+++ b/jikesrvm/build/configs/RBaseBaseSemiSpaceRelease.properties
@@ -13,6 +13,7 @@
 config.mmtk.plan=org.mmtk.plan.semispace.SS
 plan.name=SS
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RBaseBaseSemiSpaceSanity.properties
+++ b/jikesrvm/build/configs/RBaseBaseSemiSpaceSanity.properties
@@ -13,6 +13,7 @@
 config.mmtk.plan=org.mmtk.plan.semispace.SS
 plan.name=SS
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFastAdaptiveMarkSweep.properties
+++ b/jikesrvm/build/configs/RFastAdaptiveMarkSweep.properties
@@ -19,6 +19,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFastAdaptiveNoGC.properties
+++ b/jikesrvm/build/configs/RFastAdaptiveNoGC.properties
@@ -19,6 +19,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFastAdaptiveNoGCDebug.properties
+++ b/jikesrvm/build/configs/RFastAdaptiveNoGCDebug.properties
@@ -19,6 +19,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFastAdaptiveSemiSpace.properties
+++ b/jikesrvm/build/configs/RFastAdaptiveSemiSpace.properties
@@ -19,6 +19,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFastAdaptiveSemiSpaceDebug.properties
+++ b/jikesrvm/build/configs/RFastAdaptiveSemiSpaceDebug.properties
@@ -19,6 +19,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFastAdaptiveSemiSpaceDebugSanity.properties
+++ b/jikesrvm/build/configs/RFastAdaptiveSemiSpaceDebugSanity.properties
@@ -19,6 +19,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFastAdaptiveSemiSpaceSanity.properties
+++ b/jikesrvm/build/configs/RFastAdaptiveSemiSpaceSanity.properties
@@ -19,6 +19,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFullAdaptiveNoGC.properties
+++ b/jikesrvm/build/configs/RFullAdaptiveNoGC.properties
@@ -18,6 +18,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFullAdaptiveNoGCDebug.properties
+++ b/jikesrvm/build/configs/RFullAdaptiveNoGCDebug.properties
@@ -18,6 +18,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFullAdaptiveSemiSpace.properties
+++ b/jikesrvm/build/configs/RFullAdaptiveSemiSpace.properties
@@ -18,6 +18,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFullAdaptiveSemiSpaceDebug.properties
+++ b/jikesrvm/build/configs/RFullAdaptiveSemiSpaceDebug.properties
@@ -18,6 +18,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/build/configs/RFullAdaptiveSemiSpaceSanity.properties
+++ b/jikesrvm/build/configs/RFullAdaptiveSemiSpaceSanity.properties
@@ -18,6 +18,7 @@ config.runtime.compiler=opt
 config.bootimage.compiler=opt
 config.bootimage.compiler.args=-X:bc:O2
 rust.build=true
+rust.binding_side_ref_proc=false
 rust.false.comment.start=/*
 rust.false.comment.end=*/
 rust.true.comment.start=

--- a/jikesrvm/rvm/src/org/jikesrvm/runtime/Entrypoints.java
+++ b/jikesrvm/rvm/src/org/jikesrvm/runtime/Entrypoints.java
@@ -34,10 +34,10 @@ public class Entrypoints {
           getMethod(org.jikesrvm.mm.mminterface.RustScanning.class, "scanBootImage", "(Lorg/vmmagic/unboxed/Address;)V");
   public static final NormalMethod scheduleFinalizerMethod =
           getMethod(org.jikesrvm.scheduler.FinalizerThread.class, "schedule", "()V");
-  public static final NormalMethod doReferenceProcessorDelegatorScanMethod = getMethod(
-      org.jikesrvm.mm.mminterface.MemoryManager.class, "doReferenceProcessorDelegatorScan", "(Lorg/vmmagic/unboxed/Address;Lorg/vmmagic/unboxed/Address;ZZ)Z");
-  public static final NormalMethod doReferenceProcessorDelegatorForwardMethod = getMethod(
-      org.jikesrvm.mm.mminterface.MemoryManager.class, "doReferenceProcessorDelegatorForward", "(Lorg/vmmagic/unboxed/Address;Lorg/vmmagic/unboxed/Address;Z)V");
+  public static final NormalMethod doReferenceProcessingHelperScanMethod = getMethod(
+      org.jikesrvm.mm.mminterface.MemoryManager.class, "doReferenceProcessingHelperScan", "(Lorg/vmmagic/unboxed/Address;Lorg/vmmagic/unboxed/Address;ZZ)Z");
+  public static final NormalMethod doReferenceProcessingHelperForwardMethod = getMethod(
+      org.jikesrvm.mm.mminterface.MemoryManager.class, "doReferenceProcessingHelperForward", "(Lorg/vmmagic/unboxed/Address;Lorg/vmmagic/unboxed/Address;Z)V");
 
 
   // The usual causes for getField/Method() to fail are:

--- a/jikesrvm/rvm/src/org/jikesrvm/runtime/Entrypoints.java
+++ b/jikesrvm/rvm/src/org/jikesrvm/runtime/Entrypoints.java
@@ -34,6 +34,10 @@ public class Entrypoints {
           getMethod(org.jikesrvm.mm.mminterface.RustScanning.class, "scanBootImage", "(Lorg/vmmagic/unboxed/Address;)V");
   public static final NormalMethod scheduleFinalizerMethod =
           getMethod(org.jikesrvm.scheduler.FinalizerThread.class, "schedule", "()V");
+  public static final NormalMethod swiftMethod = getMethod(org.jikesrvm.mm.mminterface.MemoryManager.class, "swift",
+      "()V");
+  public static final NormalMethod doFinalizableProcessorScanMethod = getMethod(
+      org.jikesrvm.mm.mminterface.MemoryManager.class, "doFinalizableProcessorScan", "(Lorg/vmmagic/unboxed/Address;Z)V");
 
   // The usual causes for getField/Method() to fail are:
   //  1. you misspelled the class name, member name, or member signature

--- a/jikesrvm/rvm/src/org/jikesrvm/runtime/Entrypoints.java
+++ b/jikesrvm/rvm/src/org/jikesrvm/runtime/Entrypoints.java
@@ -37,7 +37,7 @@ public class Entrypoints {
   public static final NormalMethod swiftMethod = getMethod(org.jikesrvm.mm.mminterface.MemoryManager.class, "swift",
       "()V");
   public static final NormalMethod doFinalizableProcessorScanMethod = getMethod(
-      org.jikesrvm.mm.mminterface.MemoryManager.class, "doFinalizableProcessorScan", "(Lorg/vmmagic/unboxed/Address;Z)V");
+      org.jikesrvm.mm.mminterface.MemoryManager.class, "doFinalizableProcessorScan", "(Lorg/vmmagic/unboxed/Address;Lorg/vmmagic/unboxed/Address;Z)V");
 
   // The usual causes for getField/Method() to fail are:
   //  1. you misspelled the class name, member name, or member signature

--- a/jikesrvm/rvm/src/org/jikesrvm/runtime/Entrypoints.java
+++ b/jikesrvm/rvm/src/org/jikesrvm/runtime/Entrypoints.java
@@ -34,10 +34,11 @@ public class Entrypoints {
           getMethod(org.jikesrvm.mm.mminterface.RustScanning.class, "scanBootImage", "(Lorg/vmmagic/unboxed/Address;)V");
   public static final NormalMethod scheduleFinalizerMethod =
           getMethod(org.jikesrvm.scheduler.FinalizerThread.class, "schedule", "()V");
-  public static final NormalMethod swiftMethod = getMethod(org.jikesrvm.mm.mminterface.MemoryManager.class, "swift",
-      "()V");
-  public static final NormalMethod doFinalizableProcessorScanMethod = getMethod(
-      org.jikesrvm.mm.mminterface.MemoryManager.class, "doFinalizableProcessorScan", "(Lorg/vmmagic/unboxed/Address;Lorg/vmmagic/unboxed/Address;Z)V");
+  public static final NormalMethod doReferenceProcessorDelegatorScanMethod = getMethod(
+      org.jikesrvm.mm.mminterface.MemoryManager.class, "doReferenceProcessorDelegatorScan", "(Lorg/vmmagic/unboxed/Address;Lorg/vmmagic/unboxed/Address;ZZ)Z");
+  public static final NormalMethod doReferenceProcessorDelegatorForwardMethod = getMethod(
+      org.jikesrvm.mm.mminterface.MemoryManager.class, "doReferenceProcessorDelegatorForward", "(Lorg/vmmagic/unboxed/Address;Lorg/vmmagic/unboxed/Address;Z)V");
+
 
   // The usual causes for getField/Method() to fail are:
   //  1. you misspelled the class name, member name, or member signature

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.20.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=57af17fbfd94ff0df2cd3b1e504abe299ce4f0ab#57af17fbfd94ff0df2cd3b1e504abe299ce4f0ab"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=b4f45195e09e38c6deae8605c0f61eb0b534ff20#b4f45195e09e38c6deae8605c0f61eb0b534ff20"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.20.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=57af17fbfd94ff0df2cd3b1e504abe299ce4f0ab#57af17fbfd94ff0df2cd3b1e504abe299ce4f0ab"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=b4f45195e09e38c6deae8605c0f61eb0b534ff20#b4f45195e09e38c6deae8605c0f61eb0b534ff20"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -477,9 +477,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
  "thiserror",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "57af17fbfd94ff0df2cd3b1e504abe299ce4f0ab" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "b4f45195e09e38c6deae8605c0f61eb0b534ff20" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -16,7 +16,7 @@ lto = true
 [package.metadata.jikesrvm]
 # Our CI matches the following line and extract mmtk/jikesrvm. If this line is updated, please check ci yaml files and make sure it works.
 jikesrvm_repo = "https://github.com/fepicture/jikesrvm.git"
-jikesrvm_version = "c17bcbbf1b9735d5b0f784a32aa2d10bbf350f8c"
+jikesrvm_version = "be1a05fd4e3ebbe5de5058a90a593bca3243d07c"
 
 [dependencies]
 libc = "0.2"

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -15,8 +15,8 @@ lto = true
 # Metadata for the JikesRVM repository
 [package.metadata.jikesrvm]
 # Our CI matches the following line and extract mmtk/jikesrvm. If this line is updated, please check ci yaml files and make sure it works.
-jikesrvm_repo = "https://github.com/fepicture/jikesrvm.git"
-jikesrvm_version = "be1a05fd4e3ebbe5de5058a90a593bca3243d07c"
+jikesrvm_repo = "https://github.com/mmtk/jikesrvm.git"
+jikesrvm_version = "259ffacf23d414686bae3ecf843e65d25dfc376e"
 
 [dependencies]
 libc = "0.2"

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -15,8 +15,8 @@ lto = true
 # Metadata for the JikesRVM repository
 [package.metadata.jikesrvm]
 # Our CI matches the following line and extract mmtk/jikesrvm. If this line is updated, please check ci yaml files and make sure it works.
-jikesrvm_repo = "https://github.com/mmtk/jikesrvm.git"
-jikesrvm_version = "079cd07458ad6be020fadd28e22f83097c33b892"
+jikesrvm_repo = "https://github.com/fepicture/jikesrvm.git"
+jikesrvm_version = "c17bcbbf1b9735d5b0f784a32aa2d10bbf350f8c"
 
 [dependencies]
 libc = "0.2"

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -87,19 +87,14 @@ extern void* last_heap_address();
 /**
  * Reference Processing
  */
-extern void hell_world();
 extern void* get_forwarded_object(void * object_reference);
 extern bool is_reachable(void * object_reference);
-extern void add_weak_candidate(void* ref, void* referent);
-extern void add_soft_candidate(void* ref, void* referent);
-extern void add_phantom_candidate(void* ref, void* referent);
 
 extern bool get_boolean_option(char* option);
 
 /**
  * Finalization
  */
-extern void add_finalizer(void* obj);
 extern void* get_finalized_object();
 
 extern void harness_begin(void *tls);

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -88,7 +88,8 @@ extern void* last_heap_address();
  * Reference Processing
  */
 extern void hell_world();
-extern void trans_trace_local(void * trace, bool nursery);
+extern void* get_forwarded_object(void * object_reference);
+extern bool is_reachable(void * object_reference);
 extern void add_weak_candidate(void* ref, void* referent);
 extern void add_soft_candidate(void* ref, void* referent);
 extern void add_phantom_candidate(void* ref, void* referent);

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -87,6 +87,8 @@ extern void* last_heap_address();
 /**
  * Reference Processing
  */
+extern void hell_world();
+extern void trans_trace_local(void * trace, bool nursery);
 extern void add_weak_candidate(void* ref, void* referent);
 extern void add_soft_candidate(void* ref, void* referent);
 extern void add_phantom_candidate(void* ref, void* referent);

--- a/mmtk/api/mmtk.h
+++ b/mmtk/api/mmtk.h
@@ -87,14 +87,23 @@ extern void* last_heap_address();
 /**
  * Reference Processing
  */
+#ifdef BINDING_SIDE_REF_PROC
 extern void* get_forwarded_object(void * object_reference);
 extern bool is_reachable(void * object_reference);
+#else
+extern void add_weak_candidate(void* ref, void* referent);
+extern void add_soft_candidate(void* ref, void* referent);
+extern void add_phantom_candidate(void* ref, void* referent);
+#endif
 
 extern bool get_boolean_option(char* option);
 
 /**
  * Finalization
  */
+#ifndef BINDING_SIDE_REF_PROC
+extern void add_finalizer(void* obj);
+#endif
 extern void* get_finalized_object();
 
 extern void harness_begin(void *tls);

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -10,7 +10,6 @@ use mmtk::util::{Address, ObjectReference};
 use mmtk::vm::{ReferenceGlue, VMBinding};
 use mmtk::AllocationSemantics;
 use mmtk::Mutator;
-use mmtk::vm::ObjectTracerContext;
 use std::ffi::CStr;
 use std::sync::atomic::Ordering;
 use JikesRVM;
@@ -163,9 +162,6 @@ pub extern "C" fn free_bytes() -> usize {
     memory_manager::free_bytes(&SINGLETON)
 }
 
-// pub extern  "C" 
-
-
 #[no_mangle]
 pub extern "C" fn total_bytes() -> usize {
     memory_manager::total_bytes(&SINGLETON)
@@ -206,15 +202,23 @@ pub extern "C" fn modify_check(object: ObjectReference) {
 }
 
 #[no_mangle]
-pub extern "C" fn hell_world() {
-    println!("[rust] hell world from mmtk/src/api.rs:hell_world")
+pub extern "C" fn get_forwarded_object(object: ObjectReference) -> ObjectReference{
+    match object.get_forwarded_object() {
+        Some(ref_obj) => ref_obj,
+        None => ObjectReference::NULL,
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn trans_trace_local(trace_local: ObjectReference, nursery: bool) {
-    println!("[rust] trans trace local from mmtk/src/api.rs:trans_trace_local")
+pub extern "C" fn is_reachable(object: ObjectReference) -> i32 {
+    object.is_reachable() as i32
 }
 
+
+#[no_mangle]
+pub extern "C" fn hell_world() {
+    println!("[rust] hell world from mmtk/src/api.rs:hell_world")
+}
 
 #[no_mangle]
 pub extern "C" fn add_weak_candidate(reff: ObjectReference, referent: ObjectReference) {
@@ -292,13 +296,11 @@ pub extern "C" fn last_heap_address() -> Address {
 // finalization
 #[no_mangle]
 pub extern "C" fn add_finalizer(object: ObjectReference) {
-    // println!("[rust] am be called? mmtk/src/api.rs:add_finalizer");
     memory_manager::add_finalizer(&SINGLETON, object);
 }
 
 #[no_mangle]
 pub extern "C" fn get_finalized_object() -> ObjectReference {
-   //  println!("[rust] am be called? mmtk/src/api.rs:get_finalized_object");
     match memory_manager::get_finalized_object(&SINGLETON) {
         Some(obj) => obj,
         None => ObjectReference::NULL,

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -10,6 +10,7 @@ use mmtk::util::{Address, ObjectReference};
 use mmtk::vm::{ReferenceGlue, VMBinding};
 use mmtk::AllocationSemantics;
 use mmtk::Mutator;
+use mmtk::vm::ObjectTracerContext;
 use std::ffi::CStr;
 use std::sync::atomic::Ordering;
 use JikesRVM;
@@ -162,6 +163,9 @@ pub extern "C" fn free_bytes() -> usize {
     memory_manager::free_bytes(&SINGLETON)
 }
 
+// pub extern  "C" 
+
+
 #[no_mangle]
 pub extern "C" fn total_bytes() -> usize {
     memory_manager::total_bytes(&SINGLETON)
@@ -200,6 +204,17 @@ pub extern "C" fn is_mapped_address(address: Address) -> i32 {
 pub extern "C" fn modify_check(object: ObjectReference) {
     memory_manager::modify_check(&SINGLETON, object)
 }
+
+#[no_mangle]
+pub extern "C" fn hell_world() {
+    println!("[rust] hell world from mmtk/src/api.rs:hell_world")
+}
+
+#[no_mangle]
+pub extern "C" fn trans_trace_local(trace_local: ObjectReference, nursery: bool) {
+    println!("[rust] trans trace local from mmtk/src/api.rs:trans_trace_local")
+}
+
 
 #[no_mangle]
 pub extern "C" fn add_weak_candidate(reff: ObjectReference, referent: ObjectReference) {
@@ -277,11 +292,13 @@ pub extern "C" fn last_heap_address() -> Address {
 // finalization
 #[no_mangle]
 pub extern "C" fn add_finalizer(object: ObjectReference) {
+    // println!("[rust] am be called? mmtk/src/api.rs:add_finalizer");
     memory_manager::add_finalizer(&SINGLETON, object);
 }
 
 #[no_mangle]
 pub extern "C" fn get_finalized_object() -> ObjectReference {
+   //  println!("[rust] am be called? mmtk/src/api.rs:get_finalized_object");
     match memory_manager::get_finalized_object(&SINGLETON) {
         Some(obj) => obj,
         None => ObjectReference::NULL,

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -7,6 +7,10 @@ use mmtk::memory_manager;
 use mmtk::scheduler::*;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::{Address, ObjectReference};
+
+#[cfg(not(feature = "binding_side_ref_proc"))]
+use mmtk::vm::{ReferenceGlue, VMBinding};
+
 use mmtk::AllocationSemantics;
 use mmtk::Mutator;
 use std::ffi::CStr;
@@ -200,6 +204,27 @@ pub extern "C" fn modify_check(object: ObjectReference) {
     memory_manager::modify_check(&SINGLETON, object)
 }
 
+#[cfg(not(feature = "binding_side_ref_proc"))]
+#[no_mangle]
+pub extern "C" fn add_weak_candidate(reff: ObjectReference, referent: ObjectReference) {
+    <JikesRVM as VMBinding>::VMReferenceGlue::set_referent(reff, referent);
+    memory_manager::add_weak_candidate(&SINGLETON, reff)
+}
+
+#[cfg(not(feature = "binding_side_ref_proc"))]
+#[no_mangle]
+pub extern "C" fn add_soft_candidate(reff: ObjectReference, referent: ObjectReference) {
+    <JikesRVM as VMBinding>::VMReferenceGlue::set_referent(reff, referent);
+    memory_manager::add_soft_candidate(&SINGLETON, reff)
+}
+
+#[cfg(not(feature = "binding_side_ref_proc"))]
+#[no_mangle]
+pub extern "C" fn add_phantom_candidate(reff: ObjectReference, referent: ObjectReference) {
+    <JikesRVM as VMBinding>::VMReferenceGlue::set_referent(reff, referent);
+    memory_manager::add_phantom_candidate(&SINGLETON, reff)
+}
+
 #[no_mangle]
 pub extern "C" fn get_forwarded_object(object: ObjectReference) -> ObjectReference {
     match object.get_forwarded_object() {
@@ -266,6 +291,13 @@ pub extern "C" fn starting_heap_address() -> Address {
 #[no_mangle]
 pub extern "C" fn last_heap_address() -> Address {
     memory_manager::last_heap_address()
+}
+
+// finalization
+#[cfg(not(feature = "binding_side_ref_proc"))]
+#[no_mangle]
+pub extern "C" fn add_finalizer(object: ObjectReference) {
+    memory_manager::add_finalizer(&SINGLETON, object);
 }
 
 #[no_mangle]

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -7,7 +7,6 @@ use mmtk::memory_manager;
 use mmtk::scheduler::*;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::{Address, ObjectReference};
-use mmtk::vm::{ReferenceGlue, VMBinding};
 use mmtk::AllocationSemantics;
 use mmtk::Mutator;
 use std::ffi::CStr;
@@ -202,7 +201,7 @@ pub extern "C" fn modify_check(object: ObjectReference) {
 }
 
 #[no_mangle]
-pub extern "C" fn get_forwarded_object(object: ObjectReference) -> ObjectReference{
+pub extern "C" fn get_forwarded_object(object: ObjectReference) -> ObjectReference {
     match object.get_forwarded_object() {
         Some(ref_obj) => ref_obj,
         None => ObjectReference::NULL,
@@ -213,7 +212,6 @@ pub extern "C" fn get_forwarded_object(object: ObjectReference) -> ObjectReferen
 pub extern "C" fn is_reachable(object: ObjectReference) -> i32 {
     object.is_reachable() as i32
 }
-
 
 #[no_mangle]
 // We trust the name/value pointer is valid.

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -216,29 +216,6 @@ pub extern "C" fn is_reachable(object: ObjectReference) -> i32 {
 
 
 #[no_mangle]
-pub extern "C" fn hell_world() {
-    println!("[rust] hell world from mmtk/src/api.rs:hell_world")
-}
-
-#[no_mangle]
-pub extern "C" fn add_weak_candidate(reff: ObjectReference, referent: ObjectReference) {
-    <JikesRVM as VMBinding>::VMReferenceGlue::set_referent(reff, referent);
-    memory_manager::add_weak_candidate(&SINGLETON, reff)
-}
-
-#[no_mangle]
-pub extern "C" fn add_soft_candidate(reff: ObjectReference, referent: ObjectReference) {
-    <JikesRVM as VMBinding>::VMReferenceGlue::set_referent(reff, referent);
-    memory_manager::add_soft_candidate(&SINGLETON, reff)
-}
-
-#[no_mangle]
-pub extern "C" fn add_phantom_candidate(reff: ObjectReference, referent: ObjectReference) {
-    <JikesRVM as VMBinding>::VMReferenceGlue::set_referent(reff, referent);
-    memory_manager::add_phantom_candidate(&SINGLETON, reff)
-}
-
-#[no_mangle]
 // We trust the name/value pointer is valid.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 // For a syscall that returns bool, we have to return a i32 instead. See https://github.com/mmtk/mmtk-jikesrvm/issues/20
@@ -291,12 +268,6 @@ pub extern "C" fn starting_heap_address() -> Address {
 #[no_mangle]
 pub extern "C" fn last_heap_address() -> Address {
     memory_manager::last_heap_address()
-}
-
-// finalization
-#[no_mangle]
-pub extern "C" fn add_finalizer(object: ObjectReference) {
-    memory_manager::add_finalizer(&SINGLETON, object);
 }
 
 #[no_mangle]

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -78,6 +78,8 @@ impl Collection<JikesRVM> for VMCollection {
 
     fn schedule_finalization(tls: VMWorkerThread) {
         unsafe {
+         //   jtoc_call!(SWIFT_METHOD_OFFSET, tls);
+
             jtoc_call!(SCHEDULE_FINALIZER_METHOD_OFFSET, tls);
         }
     }

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -78,8 +78,6 @@ impl Collection<JikesRVM> for VMCollection {
 
     fn schedule_finalization(tls: VMWorkerThread) {
         unsafe {
-         //   jtoc_call!(SWIFT_METHOD_OFFSET, tls);
-
             jtoc_call!(SCHEDULE_FINALIZER_METHOD_OFFSET, tls);
         }
     }

--- a/mmtk/src/reference_glue.rs
+++ b/mmtk/src/reference_glue.rs
@@ -2,22 +2,54 @@ use mmtk::util::opaque_pointer::*;
 use mmtk::util::ObjectReference;
 use mmtk::vm::ReferenceGlue;
 
+#[cfg(not(feature = "binding_side_ref_proc"))]
+use entrypoint::*;
+
 use JikesRVM;
+
+#[cfg(not(feature = "binding_side_ref_proc"))]
+use std::arch::asm;
 
 pub struct VMReferenceGlue {}
 
 impl ReferenceGlue<JikesRVM> for VMReferenceGlue {
     type FinalizableType = ObjectReference;
 
-    fn set_referent(_reff: ObjectReference, _referent: ObjectReference) {
-        unimplemented!()
+    fn set_referent(reff: ObjectReference, referent: ObjectReference) {
+        if cfg!(feature = "binding_side_ref_proc") {
+            panic!();
+        } else {
+            unsafe {
+                (reff.to_raw_address() + REFERENCE_REFERENT_FIELD_OFFSET).store(referent);
+            }
+        }
     }
 
-    fn get_referent(_object: ObjectReference) -> ObjectReference {
-        unimplemented!()
+    fn get_referent(object: ObjectReference) -> ObjectReference {
+        if cfg!(feature = "binding_side_ref_proc") {
+            panic!();
+        } else {
+            debug_assert!(!object.is_null());
+            unsafe {
+                (object.to_raw_address() + REFERENCE_REFERENT_FIELD_OFFSET)
+                    .load::<ObjectReference>()
+            }
+        }
     }
 
-    fn enqueue_references(_references: &[ObjectReference], _tls: VMWorkerThread) {
-        unimplemented!()
+    fn enqueue_references(references: &[ObjectReference], tls: VMWorkerThread) {
+        if cfg!(feature = "binding_side_ref_proc") {
+            panic!();
+        } else {
+            for reff in references {
+                unsafe {
+                    jtoc_call!(
+                        ENQUEUE_REFERENCE_METHOD_OFFSET,
+                        tls,
+                        std::mem::transmute::<_, usize>(*reff)
+                    );
+                }
+            }
+        }
     }
 }

--- a/mmtk/src/reference_glue.rs
+++ b/mmtk/src/reference_glue.rs
@@ -2,10 +2,7 @@ use mmtk::util::opaque_pointer::*;
 use mmtk::util::ObjectReference;
 use mmtk::vm::ReferenceGlue;
 
-use entrypoint::*;
 use JikesRVM;
-
-use std::arch::asm;
 
 pub struct VMReferenceGlue {}
 
@@ -13,27 +10,14 @@ impl ReferenceGlue<JikesRVM> for VMReferenceGlue {
     type FinalizableType = ObjectReference;
 
     fn set_referent(reff: ObjectReference, referent: ObjectReference) {
-        unsafe {
-            (reff.to_raw_address() + REFERENCE_REFERENT_FIELD_OFFSET).store(referent);
-        }
+        unimplemented!()
     }
 
     fn get_referent(object: ObjectReference) -> ObjectReference {
-        debug_assert!(!object.is_null());
-        unsafe {
-            (object.to_raw_address() + REFERENCE_REFERENT_FIELD_OFFSET).load::<ObjectReference>()
-        }
+        unimplemented!()
     }
 
     fn enqueue_references(references: &[ObjectReference], tls: VMWorkerThread) {
-        for reff in references {
-            unsafe {
-                jtoc_call!(
-                    ENQUEUE_REFERENCE_METHOD_OFFSET,
-                    tls,
-                    std::mem::transmute::<_, usize>(*reff)
-                );
-            }
-        }
+        unimplemented!()
     }
 }

--- a/mmtk/src/reference_glue.rs
+++ b/mmtk/src/reference_glue.rs
@@ -9,15 +9,15 @@ pub struct VMReferenceGlue {}
 impl ReferenceGlue<JikesRVM> for VMReferenceGlue {
     type FinalizableType = ObjectReference;
 
-    fn set_referent(reff: ObjectReference, referent: ObjectReference) {
+    fn set_referent(_reff: ObjectReference, _referent: ObjectReference) {
         unimplemented!()
     }
 
-    fn get_referent(object: ObjectReference) -> ObjectReference {
+    fn get_referent(_object: ObjectReference) -> ObjectReference {
         unimplemented!()
     }
 
-    fn enqueue_references(references: &[ObjectReference], tls: VMWorkerThread) {
+    fn enqueue_references(_references: &[ObjectReference], _tls: VMWorkerThread) {
         unimplemented!()
     }
 }

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -21,6 +21,7 @@ use mmtk::vm::ActivePlan;
 use mmtk::vm::EdgeVisitor;
 use mmtk::vm::RootsWorkFactory;
 use mmtk::vm::Scanning;
+use mmtk::MMTK;
 use mmtk::*;
 use object_model::VMObjectModel;
 use std::mem;
@@ -227,7 +228,7 @@ where
         .generational()
         .map_or(false, |plan| plan.is_current_gc_nursery());
 
-    let need_retain = SINGLETON.get_plan().is_emergency_collection();
+    let need_retain = SINGLETON.is_emergency_collection();
 
     tracer_context.with_tracer(worker, |tracer| unsafe {
         let scan_result = jtoc_call!(

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -180,30 +180,69 @@ impl Scanning<JikesRVM> for VMScanning {
     }
 
     fn process_weak_refs(
-        _worker: &mut GCWorker<JikesRVM>,
-        _tracer_context: impl ObjectTracerContext<JikesRVM>,
+        worker: &mut GCWorker<JikesRVM>,
+        tracer_context: impl ObjectTracerContext<JikesRVM>,
     ) -> bool {
-        process_weak_refs_inner(_worker, _tracer_context)
+        process_weak_refs_inner(worker, tracer_context)
+    }
+
+    fn forward_weak_refs(
+        worker: &mut GCWorker<JikesRVM>,
+        tracer_context: impl ObjectTracerContext<JikesRVM>,
+    ) {
+        forward_weak_refs_inner(worker, tracer_context)
     }
 }
 
-fn process_weak_refs_inner<C>(_worker: &mut GCWorker<JikesRVM>, _tracer_context: C) -> bool
+fn forward_weak_refs_inner<C>(worker: &mut GCWorker<JikesRVM>, tracer_context: C)
 where
     C: ObjectTracerContext<JikesRVM>,
 {
-    let tls = _worker.tls;
-    _tracer_context.with_tracer(_worker, |tracer| {
-        unsafe {
-            jtoc_call!(
-                DO_FINALIZABLE_PROCESSOR_SCAN_METHOD_OFFSET,
-                tls,
-                trace_object_callback_for_jikesrvm::<C::TracerType>,
-                tracer as *mut _ as *mut libc::c_void,
-                0
-            );
-        }
+    let tls = worker.tls;
+
+    let is_nursery = SINGLETON
+        .get_plan()
+        .generational()
+        .map_or(false, |plan| plan.is_current_gc_nursery());
+
+    tracer_context.with_tracer(worker, |tracer| unsafe {
+        jtoc_call!(
+            DO_REFERENCE_PROCESSOR_DELEGATOR_FORWARD_METHOD_OFFSET,
+            tls,
+            trace_object_callback_for_jikesrvm::<C::TracerType>,
+            tracer as *mut _ as *mut libc::c_void,
+            is_nursery as i32
+        );
     });
-    false
+}
+
+fn process_weak_refs_inner<C>(worker: &mut GCWorker<JikesRVM>, tracer_context: C) -> bool
+where
+    C: ObjectTracerContext<JikesRVM>,
+{
+    let tls = worker.tls;
+
+    let is_nursery = SINGLETON
+        .get_plan()
+        .generational()
+        .map_or(false, |plan| plan.is_current_gc_nursery());
+
+    let need_retain = SINGLETON.get_plan().is_emergency_collection();
+
+    let mut scan_result = 0;
+
+    tracer_context.with_tracer(worker, |tracer| unsafe {
+        scan_result = jtoc_call!(
+            DO_REFERENCE_PROCESSOR_DELEGATOR_SCAN_METHOD_OFFSET,
+            tls,
+            trace_object_callback_for_jikesrvm::<C::TracerType>,
+            tracer as *mut _ as *mut libc::c_void,
+            is_nursery as i32,
+            need_retain as i32
+        );
+    });
+
+    scan_result == 0
 }
 
 impl VMScanning {

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -2,6 +2,7 @@ use std::arch::asm;
 use std::mem::size_of;
 use std::slice;
 
+use mmtk::vm::ObjectTracerContext;
 // use crate::scan_boot_image::ScanBootImageRoots;
 use crate::scan_statics::ScanStaticRoots;
 use crate::unboxed_size_constants::LOG_BYTES_IN_ADDRESS;
@@ -167,6 +168,19 @@ impl Scanning<JikesRVM> for VMScanning {
     fn prepare_for_roots_re_scanning() {
         // I guess we do not need to do anything special. However I will leave it as unimplemented for now.
         unimplemented!()
+    }
+
+    fn process_weak_refs(
+        _worker: &mut GCWorker<JikesRVM>,
+        _tracer_context: impl ObjectTracerContext<JikesRVM>,
+    ) -> bool {
+        let tls = _worker.tls;
+        _tracer_context.with_tracer(_worker,  |tracer| {
+            unsafe {
+                jtoc_call!(DO_FINALIZABLE_PROCESSOR_SCAN_METHOD_OFFSET, tls, tracer, 0);
+            }
+        });
+        false
     }
 }
 

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -207,7 +207,7 @@ where
 
     tracer_context.with_tracer(worker, |tracer| unsafe {
         jtoc_call!(
-            DO_REFERENCE_PROCESSOR_DELEGATOR_FORWARD_METHOD_OFFSET,
+            DO_REFERENCE_PROCESSING_HELPER_FORWARD_METHOD_OFFSET,
             tls,
             trace_object_callback_for_jikesrvm::<C::TracerType>,
             tracer as *mut _ as *mut libc::c_void,
@@ -229,20 +229,17 @@ where
 
     let need_retain = SINGLETON.get_plan().is_emergency_collection();
 
-    let mut scan_result = 0;
-
     tracer_context.with_tracer(worker, |tracer| unsafe {
-        scan_result = jtoc_call!(
-            DO_REFERENCE_PROCESSOR_DELEGATOR_SCAN_METHOD_OFFSET,
+        let scan_result = jtoc_call!(
+            DO_REFERENCE_PROCESSING_HELPER_SCAN_METHOD_OFFSET,
             tls,
             trace_object_callback_for_jikesrvm::<C::TracerType>,
             tracer as *mut _ as *mut libc::c_void,
             is_nursery as i32,
             need_retain as i32
         );
-    });
-
-    scan_result == 0
+        scan_result == 0
+    })
 }
 
 impl VMScanning {


### PR DESCRIPTION
_edit v1: sync latest status, i have finish the reference processor and integrate together._
_edit v2: update with binding PR link._

fix #145 
mmtk-jikesrvm PR https://github.com/mmtk/mmtk-jikesrvm/pull/150
jikesRVM PR https://github.com/mmtk/jikesrvm/pull/16

Modifications to the mmtk-jikesrvm repository encompass three key aspects:

1. I have removed some old bind APIs, marking them as unimplement, or directly removing them.
2. I implemented the process_weak_ref and forward_weak_ref methods. These will be invoked in the work bucket and act as an entry point for the original process in jikesrvm.
3. Lastly, the CI heap configuration has been updated.