### PR TITLE
Reproduce JikesRVM CI failure in core PR #1026

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.21.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=39d237189fdfa22873eeb529f3e97b7578d9b246#39d237189fdfa22873eeb529f3e97b7578d9b246"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c#9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.21.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=39d237189fdfa22873eeb529f3e97b7578d9b246#39d237189fdfa22873eeb529f3e97b7578d9b246"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c#9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.21.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c#9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=28bc5130feca058147c013f6629e0cdcf15e6e58#28bc5130feca058147c013f6629e0cdcf15e6e58"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.21.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c#9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=28bc5130feca058147c013f6629e0cdcf15e6e58#28bc5130feca058147c013f6629e0cdcf15e6e58"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.21.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=28bc5130feca058147c013f6629e0cdcf15e6e58#28bc5130feca058147c013f6629e0cdcf15e6e58"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=073664a6c78dc9c376ae4134b9bb71246047a40c#073664a6c78dc9c376ae4134b9bb71246047a40c"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.21.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=28bc5130feca058147c013f6629e0cdcf15e6e58#28bc5130feca058147c013f6629e0cdcf15e6e58"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=073664a6c78dc9c376ae4134b9bb71246047a40c#073664a6c78dc9c376ae4134b9bb71246047a40c"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.21.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=073664a6c78dc9c376ae4134b9bb71246047a40c#073664a6c78dc9c376ae4134b9bb71246047a40c"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=44ba9d75b2ced795ae60bb7af983124dabf277b4#44ba9d75b2ced795ae60bb7af983124dabf277b4"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.21.0"
-source = "git+https://github.com/qinsoon/mmtk-core.git?rev=073664a6c78dc9c376ae4134b9bb71246047a40c#073664a6c78dc9c376ae4134b9bb71246047a40c"
+source = "git+https://github.com/qinsoon/mmtk-core.git?rev=44ba9d75b2ced795ae60bb7af983124dabf277b4#44ba9d75b2ced795ae60bb7af983124dabf277b4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "073664a6c78dc9c376ae4134b9bb71246047a40c" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "44ba9d75b2ced795ae60bb7af983124dabf277b4" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "28bc5130feca058147c013f6629e0cdcf15e6e58" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "073664a6c78dc9c376ae4134b9bb71246047a40c" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "39d237189fdfa22873eeb529f3e97b7578d9b246" }
+mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -28,7 +28,7 @@ log = {version = "0.4", features = ["max_level_trace", "release_max_level_off"] 
 # - change branch/rev
 # - change repo name
 # But other changes including adding/removing whitespaces in commented lines may break the CI.
-mmtk = { git = "https://github.com/mmtk/mmtk-core.git", rev = "9786ce8befb1078e08e97ecd7fc74ca4ffdfcf7c" }
+mmtk = { git = "https://github.com/qinsoon/mmtk-core.git", rev = "28bc5130feca058147c013f6629e0cdcf15e6e58" }
 # Uncomment the following to build locally - if you change the path locally, do not commit the change in a PR
 # mmtk = { path = "../repos/mmtk-core" }
 


### PR DESCRIPTION
JikesRVM tests keeps failing in https://github.com/mmtk/mmtk-core/pull/1026. It is reproducible in our CI, but I cannot reproduce it locally. I am trying to narrow down the issue and see when the issue was introduced.