### PR TITLE
CI: Run tests without ASLR

### DIFF
--- a/.github/scripts/ci-test-assertions-use-bind-ref-proc.sh
+++ b/.github/scripts/ci-test-assertions-use-bind-ref-proc.sh
@@ -7,10 +7,10 @@ cd $JIKESRVM_PATH
 
 # RBaseBaseSemiSpaceAssertions
 ./bin/buildit localhost RBaseBaseSemiSpaceAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 
 # RBaseBaseMarkSweepAssertions
 ./bin/buildit localhost RBaseBaseMarkSweepAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex

--- a/.github/scripts/ci-test-assertions.sh
+++ b/.github/scripts/ci-test-assertions.sh
@@ -7,10 +7,10 @@ cd $JIKESRVM_PATH
 
 # RBaseBaseSemiSpaceAssertions
 ./bin/buildit localhost RBaseBaseSemiSpaceAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RBaseBaseSemiSpaceAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
 
 # RBaseBaseMarkSweepAssertions
 ./bin/buildit localhost RBaseBaseMarkSweepAssertions -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RBaseBaseMarkSweepAssertions_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex

--- a/.github/scripts/ci-test-normal-use-bind-ref-proc.sh
+++ b/.github/scripts/ci-test-normal-use-bind-ref-proc.sh
@@ -17,52 +17,52 @@ find "$PROPERTIES_DIR" -type f -name "*.properties" -exec sed -i 's/rust.binding
 
 # RBaseBaseNoGC
 ./bin/buildit localhost RBaseBaseNoGC -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1224M -Xms1224M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1224M -Xms1224M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 # RBaseBaseSemiSpace
 ./bin/buildit localhost RBaseBaseSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx400M -Xms400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx400M -Xms400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 
 # Test FastAdaptive builds
 # Run all possible dacapo benchmarks
 
 # RFastAdaptiveNoGC (use largest heap possible)
 ./bin/buildit localhost RFastAdaptiveNoGC -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
 
 export MMTK_THREADS=16
 
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms2000M -Xmx2000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-#fail./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1500M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+#fail setarch -R  ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms2000M -Xmx2000M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1500M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
 
 # Flaky test: Failing instruction starting at xxxxx wasn't in RVM address space
 # see https://github.com/mmtk/mmtk-jikesrvm/issues/108
-#./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+#setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
-#./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-#fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1100M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-#fail./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms800M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+#setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1100M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms650M -Xmx650M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms800M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 find "$PROPERTIES_DIR" -type f -name "*.properties" -exec sed -i 's/rust.binding_side_ref_proc=true/rust.binding_side_ref_proc=false/' {} \;

--- a/.github/scripts/ci-test-normal.sh
+++ b/.github/scripts/ci-test-normal.sh
@@ -10,46 +10,46 @@ cd $JIKESRVM_PATH
 
 # RBaseBaseNoGC
 ./bin/buildit localhost RBaseBaseNoGC -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1024M -Xms1024M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RBaseBaseNoGC_x86_64_m32-linux/rvm -Xmx1024M -Xms1024M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 # RBaseBaseSemiSpace
 ./bin/buildit localhost RBaseBaseSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx75M -Xms75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RBaseBaseSemiSpace_x86_64_m32-linux/rvm -Xmx75M -Xms75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
 
 # Test FastAdaptive builds
 # Run all possible dacapo benchmarks
 
 # RFastAdaptiveNoGC (use largest heap possible)
 ./bin/buildit localhost RFastAdaptiveNoGC -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RFastAdaptiveNoGC_x86_64_m32-linux/rvm -Xms3G -Xmx3G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
 
 export MMTK_THREADS=16
 
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
-#./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+# setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan

--- a/.github/scripts/ci-test-weak-ref-use-bind-ref-proc.sh
+++ b/.github/scripts/ci-test-weak-ref-use-bind-ref-proc.sh
@@ -20,35 +20,35 @@ find "$PROPERTIES_DIR" -type f -name "*.properties" -exec sed -i 's/rust.binding
 
 
 # RFastAdaptiveSemiSpace
-./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms2G -Xmx2G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-#fail ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1500M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1800M -Xmx1800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+setarch -R ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
+#fail setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms2G -Xmx2G -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms900M -Xmx900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1900M -Xmx1900M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+#fail setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1500M -Xmx1500M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1800M -Xmx1800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms400M -Xmx400M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
 
 # Flaky test: Failing instruction starting at xxxxx wasn't in RVM address space
 # see https://github.com/mmtk/mmtk-jikesrvm/issues/108
-# ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+# setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
-# ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-#fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1100M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-#fail ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms800M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms950M -Xmx950M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+# setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms350M -Xmx350M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+#fail setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms1100M -Xmx1100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms600M -Xmx600M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+#fail setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms800M -Xmx800M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms950M -Xmx950M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # Find all .properties files and update them using sed
 find "$PROPERTIES_DIR" -type f -name "*.properties" -exec sed -i 's/rust.binding_side_ref_proc=true/rust.binding_side_ref_proc=false/' {} \;

--- a/.github/scripts/ci-test-weak-ref.sh
+++ b/.github/scripts/ci-test-weak-ref.sh
@@ -13,27 +13,27 @@ RVM_OPTIONS=-X:gc:no_reference_types=false
 
 # RFastAdaptiveSemiSpace
 ./bin/buildit localhost RFastAdaptiveSemiSpace -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms200M -Xmx200M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms75M -Xmx75M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveSemiSpace_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms100M -Xmx100M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
 
 # RFastAdaptiveMarkSweep
 ./bin/buildit localhost RFastAdaptiveMarkSweep -j $JAVA_HOME --answer-yes --use-third-party-heap=$BINDING_PATH/ --use-third-party-build-configs=$BINDING_PATH/jikesrvm/build/configs --use-external-source=$BINDING_PATH/jikesrvm/rvm/src --m32
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar antlr
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar bloat
 # Failing instruction offset: 0x000000c3 in method ___ with descriptor ___ Couldn't find a method for given instruction offset
-#./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
-./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan
+# setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar eclipse
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar fop
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms300M -Xmx300M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar hsqldb
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar jython
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar luindex
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar lusearch
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar pmd
+setarch -R ./dist/RFastAdaptiveMarkSweep_x86_64_m32-linux/rvm $RVM_OPTIONS -Xms150M -Xmx150M -jar $DACAPO_PATH/dacapo-2006-10-MR2.jar xalan


### PR DESCRIPTION
The boot images are built with the assumption that they will be loaded at a specific address.  ASLR will cause some shared objects to be loaded at the addresses of the boot images, and the boot images will overwrite their sections, causing illegal instruction errors and other errors.  This problem is easy to reproduce locally, and manifests very frequently when running on GitHub CI.

This PR modifies CI scripts to mitigate the problem.  It adds `setarch -R`  before executing `rvm` to disable ASLR.

This PR is a workaround.  The proper fix is take control over the loading process and not let the system loader load shared objects in the address range of the boot image.

Related issue: https://github.com/mmtk/mmtk-jikesrvm/issues/158