### PR TITLE
Introduce JikesRVM-specific object accessor types

### DIFF
--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -315,11 +315,11 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
         let copy = from != to;
 
         let bytes = if copy {
-            let bytes = Self::bytes_required_when_copied(from, rvm_type);
+            let bytes = JikesObj::from(from).bytes_required_when_copied(rvm_type);
             Self::move_object(from, MoveTarget::ToObject(to), bytes, rvm_type);
             bytes
         } else {
-            Self::bytes_used(from, rvm_type)
+            JikesObj::from(from).bytes_used(rvm_type)
         };
 
         let start = Self::ref_to_object_start(to);
@@ -346,13 +346,13 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
         trace!("ObjectModel.get_current_size");
         let rvm_type = JikesObj::from(object).load_rvm_type();
 
-        Self::bytes_used(object, rvm_type)
+        JikesObj::from(object).bytes_used(rvm_type)
     }
 
     fn get_size_when_copied(object: ObjectReference) -> usize {
         let rvm_type = JikesObj::from(object).load_rvm_type();
 
-        Self::bytes_required_when_copied(object, rvm_type)
+        JikesObj::from(object).bytes_required_when_copied(rvm_type)
     }
 
     fn get_align_when_copied(object: ObjectReference) -> usize {
@@ -420,7 +420,7 @@ impl VMObjectModel {
         copy_context: &mut GCWorkerCopyContext<JikesRVM>,
     ) -> ObjectReference {
         trace!("VMObjectModel.copy_scalar");
-        let bytes = Self::bytes_required_when_copied_class(from, rvm_type);
+        let bytes = JikesObj::from(from).bytes_required_when_copied_class(rvm_type);
         let align = Self::get_alignment_class(rvm_type);
         let offset = Self::get_offset_for_alignment_class(from, rvm_type);
         let region = copy_context.alloc_copy(from, bytes, align, offset, copy);
@@ -439,7 +439,7 @@ impl VMObjectModel {
         copy_context: &mut GCWorkerCopyContext<JikesRVM>,
     ) -> ObjectReference {
         trace!("VMObjectModel.copy_array");
-        let bytes = Self::bytes_required_when_copied_array(from, rvm_type);
+        let bytes = JikesObj::from(from).bytes_required_when_copied_array(rvm_type);
         let align = Self::get_alignment_array(rvm_type);
         let offset = Self::get_offset_for_alignment_array(from, rvm_type);
         let region = copy_context.alloc_copy(from, bytes, align, offset, copy);
@@ -448,30 +448,6 @@ impl VMObjectModel {
         copy_context.post_copy(to_obj, bytes, copy);
         // XXX: Do not sync icache/dcache because we do not support PowerPC
         to_obj
-    }
-
-    #[inline(always)]
-    fn bytes_required_when_copied(object: ObjectReference, rvm_type: RVMType) -> usize {
-        trace!("VMObjectModel.bytes_required_when_copied");
-        JikesObj::from(object).bytes_required_when_copied(rvm_type)
-    }
-
-    #[inline(always)]
-    fn bytes_required_when_copied_class(object: ObjectReference, rvm_type: RVMType) -> usize {
-        trace!("VMObjectModel.bytes_required_when_copied_class");
-        JikesObj::from(object).bytes_required_when_copied_class(rvm_type)
-    }
-
-    #[inline(always)]
-    fn bytes_required_when_copied_array(object: ObjectReference, rvm_type: RVMType) -> usize {
-        trace!("VMObjectModel.bytes_required_when_copied_array");
-        JikesObj::from(object).bytes_required_when_copied_array(rvm_type)
-    }
-
-    #[inline(always)]
-    fn bytes_used(object: ObjectReference, rvm_type: RVMType) -> usize {
-        trace!("VMObjectModel.bytes_used");
-        JikesObj::from(object).bytes_used(rvm_type)
     }
 
     #[inline(always)]

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -359,9 +359,9 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
         let rvm_type = JikesObj::from(object).load_rvm_type();
 
         if rvm_type.is_class() {
-            Self::get_alignment_class(rvm_type)
+            rvm_type.get_alignment_class()
         } else {
-            Self::get_alignment_array(rvm_type)
+            rvm_type.get_alignment_array()
         }
     }
 
@@ -369,9 +369,9 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
         let rvm_type = JikesObj::from(object).load_rvm_type();
 
         if rvm_type.is_class() {
-            Self::get_offset_for_alignment_class(object, rvm_type)
+            JikesObj::from(object).get_offset_for_alignment_class()
         } else {
-            Self::get_offset_for_alignment_array(object, rvm_type)
+            JikesObj::from(object).get_offset_for_alignment_array()
         }
     }
 
@@ -421,8 +421,8 @@ impl VMObjectModel {
     ) -> ObjectReference {
         trace!("VMObjectModel.copy_scalar");
         let bytes = JikesObj::from(from).bytes_required_when_copied_class(rvm_type);
-        let align = Self::get_alignment_class(rvm_type);
-        let offset = Self::get_offset_for_alignment_class(from, rvm_type);
+        let align = rvm_type.get_alignment_class();
+        let offset = JikesObj::from(from).get_offset_for_alignment_class();
         let region = copy_context.alloc_copy(from, bytes, align, offset, copy);
 
         let to_obj = Self::move_object(from, MoveTarget::ToAddress(region), bytes, rvm_type);
@@ -440,8 +440,8 @@ impl VMObjectModel {
     ) -> ObjectReference {
         trace!("VMObjectModel.copy_array");
         let bytes = JikesObj::from(from).bytes_required_when_copied_array(rvm_type);
-        let align = Self::get_alignment_array(rvm_type);
-        let offset = Self::get_offset_for_alignment_array(from, rvm_type);
+        let align = rvm_type.get_alignment_array();
+        let offset = JikesObj::from(from).get_offset_for_alignment_array();
         let region = copy_context.alloc_copy(from, bytes, align, offset, copy);
 
         let to_obj = Self::move_object(from, MoveTarget::ToAddress(region), bytes, rvm_type);
@@ -548,29 +548,5 @@ impl VMObjectModel {
         } else {
             memcpy(dst.to_mut_ptr(), src.to_mut_ptr(), cnt);
         }
-    }
-
-    #[inline(always)]
-    fn get_alignment_array(rvm_type: RVMType) -> usize {
-        trace!("VMObjectModel.get_alignment_array");
-        rvm_type.get_alignment_array()
-    }
-
-    #[inline(always)]
-    fn get_alignment_class(rvm_type: RVMType) -> usize {
-        trace!("VMObjectModel.get_alignment_class");
-        rvm_type.get_alignment_class()
-    }
-
-    #[inline(always)]
-    fn get_offset_for_alignment_array(object: ObjectReference, _rvm_type: RVMType) -> usize {
-        trace!("VMObjectModel.get_offset_for_alignment_array");
-        JikesObj::from(object).get_offset_for_alignment_array()
-    }
-
-    #[inline(always)]
-    fn get_offset_for_alignment_class(object: ObjectReference, _rvm_type: RVMType) -> usize {
-        trace!("VMObjectModel.get_offset_for_alignment_class");
-        JikesObj::from(object).get_offset_for_alignment_class()
     }
 }

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -279,11 +279,6 @@ pub struct VMObjectModel {}
 
 impl VMObjectModel {
     #[inline(always)]
-    pub fn load_rvm_type(object: ObjectReference) -> RVMType {
-        JikesObj::from(object).load_rvm_type()
-    }
-
-    #[inline(always)]
     pub fn load_tib(object: ObjectReference) -> TIB {
         JikesObj::from(object).load_tib()
     }
@@ -325,7 +320,7 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
     ) -> ObjectReference {
         trace!("ObjectModel.copy");
         let tib = Self::load_tib(from);
-        let rvm_type = Self::load_rvm_type(from);
+        let rvm_type = JikesObj::from(from).load_rvm_type();
 
         trace!("Is it a class?");
         if rvm_type.is_class() {
@@ -340,7 +335,7 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
     #[inline(always)]
     fn copy_to(from: ObjectReference, to: ObjectReference, region: Address) -> Address {
         trace!("ObjectModel.copy_to");
-        let rvm_type = Self::load_rvm_type(from);
+        let rvm_type = JikesObj::from(from).load_rvm_type();
 
         let copy = from != to;
 
@@ -374,19 +369,19 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
 
     fn get_current_size(object: ObjectReference) -> usize {
         trace!("ObjectModel.get_current_size");
-        let rvm_type = Self::load_rvm_type(object);
+        let rvm_type = JikesObj::from(object).load_rvm_type();
 
         Self::bytes_used(object, rvm_type)
     }
 
     fn get_size_when_copied(object: ObjectReference) -> usize {
-        let rvm_type = Self::load_rvm_type(object);
+        let rvm_type = JikesObj::from(object).load_rvm_type();
 
         Self::bytes_required_when_copied(object, rvm_type)
     }
 
     fn get_align_when_copied(object: ObjectReference) -> usize {
-        let rvm_type = Self::load_rvm_type(object);
+        let rvm_type = JikesObj::from(object).load_rvm_type();
 
         if rvm_type.is_class() {
             Self::get_alignment_class(rvm_type)
@@ -396,7 +391,7 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
     }
 
     fn get_align_offset_when_copied(object: ObjectReference) -> usize {
-        let rvm_type = Self::load_rvm_type(object);
+        let rvm_type = JikesObj::from(object).load_rvm_type();
 
         if rvm_type.is_class() {
             Self::get_offset_for_alignment_class(object, rvm_type)

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -278,11 +278,6 @@ static HASH_TRANSITION2: AtomicUsize = AtomicUsize::new(0);
 pub struct VMObjectModel {}
 
 impl VMObjectModel {
-    #[inline(always)]
-    pub fn load_tib(object: ObjectReference) -> TIB {
-        JikesObj::from(object).load_tib()
-    }
-
     #[allow(dead_code)]
     pub(crate) fn get_align_when_copied(object: ObjectReference) -> usize {
         trace!("ObjectModel.get_align_when_copied");
@@ -319,8 +314,8 @@ impl ObjectModel<JikesRVM> for VMObjectModel {
         copy_context: &mut GCWorkerCopyContext<JikesRVM>,
     ) -> ObjectReference {
         trace!("ObjectModel.copy");
-        let tib = Self::load_tib(from);
-        let rvm_type = JikesObj::from(from).load_rvm_type();
+        let tib = JikesObj::from(from).load_tib();
+        let rvm_type = tib.load_rvm_type();
 
         trace!("Is it a class?");
         if rvm_type.is_class() {

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -278,18 +278,6 @@ static HASH_TRANSITION2: AtomicUsize = AtomicUsize::new(0);
 pub struct VMObjectModel {}
 
 impl VMObjectModel {
-    #[allow(dead_code)]
-    pub(crate) fn get_align_when_copied(object: ObjectReference) -> usize {
-        trace!("ObjectModel.get_align_when_copied");
-        JikesObj::from(object).get_align_when_copied()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn get_align_offset_when_copied(object: ObjectReference) -> usize {
-        trace!("ObjectModel.get_align_offset_when_copied");
-        JikesObj::from(object).get_align_offset_when_copied()
-    }
-
     #[inline(always)]
     pub(crate) fn get_array_length(object: ObjectReference) -> usize {
         trace!("ObjectModel.get_array_length");

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -277,14 +277,6 @@ static HASH_TRANSITION2: AtomicUsize = AtomicUsize::new(0);
 #[derive(Default)]
 pub struct VMObjectModel {}
 
-impl VMObjectModel {
-    #[inline(always)]
-    pub(crate) fn get_array_length(object: ObjectReference) -> usize {
-        trace!("ObjectModel.get_array_length");
-        JikesObj::from(object).get_array_length()
-    }
-}
-
 impl ObjectModel<JikesRVM> for VMObjectModel {
     const GLOBAL_LOG_BIT_SPEC: VMGlobalLogBitSpec = vm_metadata::LOGGING_SIDE_METADATA_SPEC;
 

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -24,7 +24,6 @@ use mmtk::vm::Scanning;
 use mmtk::vm::SlotVisitor;
 use mmtk::MMTK;
 use mmtk::*;
-use object_model::VMObjectModel;
 use std::mem;
 use JikesRVM;
 use JTOC_BASE;
@@ -112,7 +111,7 @@ impl Scanning<JikesRVM> for VMScanning {
         // In a class with pointers, it contains the offsets of reference-containing instance fields
         if elt0_ptr == 0 {
             // object is a REFARRAY
-            let length = VMObjectModel::get_array_length(object);
+            let length = JikesObj::from(object).get_array_length();
             for i in 0..length {
                 slot_visitor.visit_slot(object.to_raw_address() + (i << LOG_BYTES_IN_ADDRESS));
             }

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -101,9 +101,9 @@ impl Scanning<JikesRVM> for VMScanning {
             }
         }
         trace!("Getting reference array");
-        let elt0_ptr: usize = unsafe {
+        let elt0_ptr: usize = {
             let rvm_type = VMObjectModel::load_rvm_type(object);
-            (rvm_type + REFERENCE_OFFSETS_FIELD_OFFSET).load::<usize>()
+            rvm_type.reference_offsets()
         };
         trace!("elt0_ptr: {}", elt0_ptr);
         // In a primitive array this field points to a zero-length array.

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -2,6 +2,7 @@ use std::arch::asm;
 use std::mem::size_of;
 use std::slice;
 
+use crate::object_model::JikesObj;
 use mmtk::vm::ObjectTracer;
 use mmtk::vm::ObjectTracerContext;
 // use crate::scan_boot_image::ScanBootImageRoots;
@@ -102,7 +103,7 @@ impl Scanning<JikesRVM> for VMScanning {
         }
         trace!("Getting reference array");
         let elt0_ptr: usize = {
-            let rvm_type = VMObjectModel::load_rvm_type(object);
+            let rvm_type = JikesObj::from(object).load_rvm_type();
             rvm_type.reference_offsets()
         };
         trace!("elt0_ptr: {}", elt0_ptr);


### PR DESCRIPTION
Introduce a JikesRVM-specific reference type `JikesObj` that represents the `ObjectReference` type in JikesRVM, but is a distinct type from the `ObjectReference` type in mmtk-core.  Also introduce `TIB` and `RVMType` wrapper types for their addresses.  Methods for querying object layouts, loading/storing object headers,and loading `RVMType` fields are off-loaded from `VMObjectModel` to those types.

The immediate effect is cleaning up the code, especially reorganizing the code pattern `(address + SOME_FIELD_OFFSET).load::<usize>()` scattered everywhere, and making the code more readable.

The ultimate purpose of this is allowing us to require the MMTk-level `ObjectReference` to always point into an object, as described in https://github.com/mmtk/mmtk-core/issues/1170.  `JikesObj` and `ObjectReference` can be converted between each other.  They currently have the same value, but we may redefine the MMTk-level `ObjectReference` in the future so that the conversion involves an offset.
