### PR TITLE
Use JavaHeader address as ObjectReference

### DIFF
--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -46,10 +46,10 @@ pub struct JikesRVM;
 
 /// The type of slots in JikesRVM.
 ///
-/// Each slot holds a `JikesObj` value, which is equal to the JikesRVM-level `ObjectReference`. The
-/// Java parts of the binding may insert `Address` values into native arrays of `JikesRVMSlot`
-/// passed from Rust code, so this type has `repr(transparent)` to make sure it has the same layout
-/// as `Address`
+/// Each slot holds a `JikesObj` value.  Conversion between `JikesObj` and the MMTk-level
+/// `ObjectReference` happens when loading from or storing to a slot. The Java parts of the binding
+/// may use raw memory access to insert `Address` into Rust arrays of `JikesRVMSlot`, so this type
+/// has `repr(transparent)` to make sure it has the same layout as `Address`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct JikesRVMSlot(Address);


### PR DESCRIPTION
This PR changes the definition of MMTk-level `ObjectReference` for the JikesRVM binding so that it now points to the JavaHeader, and is different from the JikesRVM-level `ObjectReference` (a.k.a. `JikesObj`).  This will guarantee that the MMTk-level ObjectReference is always inside an object.

Note that this PR does not involve a change in mmtk-core.  It changes `ObjectModel::IN_OBJECT_ADDRESS_OFFSET` to 0 so that the "in-object address" is identical to the raw address of `ObjectReference`.  It demonstrates the JikesRVM binding can work well with MMTk-level `ObjectReference` being different from JikesRVM-level `ObjectReference`.

Related issues and PRs.
-   This PR is based on https://github.com/mmtk/mmtk-jikesrvm/pull/177
-   This PR is the 2nd step of https://github.com/mmtk/mmtk-jikesrvm/issues/178
-   It will ultimately allow https://github.com/mmtk/mmtk-core/issues/1170 to be implemented.
 