### PR TITLE
Migrate to Rust 2021 edition

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -3,6 +3,7 @@ name = "mmtk_jikesrvm"
 version = "0.26.0"
 authors = [" <>"]
 rust-version = "1.71.1"
+edition = "2021"
 
 [lib]
 name = "mmtk_jikesrvm"

--- a/mmtk/src/active_plan.rs
+++ b/mmtk/src/active_plan.rs
@@ -1,12 +1,12 @@
-use collection::VMCollection;
-use entrypoint::*;
+use crate::collection::VMCollection;
+use crate::entrypoint::*;
+use crate::JikesRVM;
+use crate::JTOC_BASE;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::Address;
 use mmtk::vm::ActivePlan;
 use mmtk::Mutator;
 use std::mem;
-use JikesRVM;
-use JTOC_BASE;
 
 use std::sync::{Mutex, MutexGuard};
 

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -1,7 +1,11 @@
+use crate::collection::VMCollection;
+use crate::collection::BOOT_THREAD;
 use crate::object_model::JikesObj;
 use crate::scanning::SLOTS_BUFFER_CAPACITY;
-use collection::VMCollection;
-use collection::BOOT_THREAD;
+use crate::JikesRVM;
+use crate::BUILDER;
+use crate::JTOC_BASE;
+use crate::SINGLETON;
 use libc::c_char;
 use libc::c_void;
 use mmtk::memory_manager;
@@ -13,10 +17,6 @@ use mmtk::Mutator;
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::sync::atomic::Ordering;
-use JikesRVM;
-use BUILDER;
-use JTOC_BASE;
-use SINGLETON;
 
 /// # Safety
 /// Caller needs to make sure the ptr is a valid vector pointer.

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -1,12 +1,12 @@
-use entrypoint::*;
+use crate::entrypoint::*;
+use crate::JikesRVM;
+use crate::JTOC_BASE;
 use mmtk::util::alloc::AllocationError;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::Address;
 use mmtk::vm::ActivePlan;
 use mmtk::vm::{Collection, GCThreadContext};
 use mmtk::Mutator;
-use JikesRVM;
-use JTOC_BASE;
 
 use crate::jikesrvm_calls;
 

--- a/mmtk/src/heap_layout_constants.rs
+++ b/mmtk/src/heap_layout_constants.rs
@@ -1,5 +1,5 @@
-use boot_image_size::CODE_SIZE_ADJUSTMENT;
-use boot_image_size::DATA_SIZE_ADJUSTMENT;
+use crate::boot_image_size::CODE_SIZE_ADJUSTMENT;
+use crate::boot_image_size::DATA_SIZE_ADJUSTMENT;
 use mmtk::util::Address;
 
 /** The traditional 32-bit heap layout */

--- a/mmtk/src/java_header.rs
+++ b/mmtk/src/java_header.rs
@@ -1,5 +1,5 @@
-use java_header_constants;
-use java_header_constants::*;
+use crate::java_header_constants;
+use crate::java_header_constants::*;
 use std::sync::atomic::AtomicUsize;
 
 pub const SCALAR_HEADER_SIZE: usize = JAVA_HEADER_BYTES + OTHER_HEADER_BYTES;

--- a/mmtk/src/java_header_constants.rs
+++ b/mmtk/src/java_header_constants.rs
@@ -1,8 +1,8 @@
+use crate::java_size_constants::*;
+use crate::memory_manager_constants;
+use crate::memory_manager_constants::*;
+use crate::misc_header_constants::*;
 use crate::unboxed_size_constants::*;
-use java_size_constants::*;
-use memory_manager_constants;
-use memory_manager_constants::*;
-use misc_header_constants::*;
 
 /** Number of bytes in object's TIB pointer */
 pub const TIB_BYTES: usize = BYTES_IN_ADDRESS;

--- a/mmtk/src/jikesrvm_calls/helpers.rs
+++ b/mmtk/src/jikesrvm_calls/helpers.rs
@@ -13,8 +13,7 @@ use crate::object_model::JikesObj;
 #[macro_export]
 macro_rules! jtoc_call {
     ($offset:ident, $tls:ident $(, $arg:ident)*) => ({
-        use JTOC_BASE;
-        let call_addr = (JTOC_BASE + $offset).load::<fn()>();
+        let call_addr = ($crate::JTOC_BASE + $offset).load::<fn()>();
         jikesrvm_call!(call_addr, $tls $(, $arg)*)
     });
 }
@@ -23,8 +22,7 @@ macro_rules! jtoc_call {
 #[macro_export]
 macro_rules! jikesrvm_instance_call {
     ($obj:ident, $offset:ident, $tls:ident $(, $arg:ident)*) => ({
-        use java_header::TIB_OFFSET;
-        let tib = ($obj + TIB_OFFSET).load::<Address>();
+        let tib = ($obj + $crate::java_header::TIB_OFFSET).load::<Address>();
         let call_addr = (tib + $offset).load::<fn()>();
         jikesrvm_call!(call_addr, $tls $(, $arg)*)
     });

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-extern crate mmtk;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -13,8 +11,8 @@ use mmtk::vm::VMBinding;
 use mmtk::MMTKBuilder;
 use mmtk::MMTK;
 
-use collection::BOOT_THREAD;
-use object_model::JikesObj;
+use crate::collection::BOOT_THREAD;
+use crate::object_model::JikesObj;
 
 pub mod active_plan;
 pub mod api;

--- a/mmtk/src/misc_header_constants.rs
+++ b/mmtk/src/misc_header_constants.rs
@@ -1,5 +1,5 @@
+use crate::memory_manager_constants::*;
 use crate::unboxed_size_constants::*;
-use memory_manager_constants::*;
 
 /* amount by which tracing causes headers to grow */
 // XXX: workaround for not having const if-expressions

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -11,17 +11,17 @@ use mmtk::util::copy::*;
 use mmtk::util::{Address, ObjectReference};
 use mmtk::vm::*;
 
-use entrypoint::*;
-use java_header::*;
-use java_header_constants::{
+use crate::entrypoint::*;
+use crate::java_header::*;
+use crate::java_header_constants::{
     ADDRESS_BASED_HASHING, ALIGNMENT_MASK, ARRAY_LENGTH_OFFSET, DYNAMIC_HASH_OFFSET,
     HASHCODE_BYTES, HASHCODE_OFFSET, HASH_STATE_HASHED, HASH_STATE_HASHED_AND_MOVED,
     HASH_STATE_MASK, HASH_STATE_UNHASHED,
 };
-use java_size_constants::{BYTES_IN_DOUBLE, BYTES_IN_INT};
-use memory_manager_constants::*;
-use tib_layout_constants::*;
-use JikesRVM;
+use crate::java_size_constants::{BYTES_IN_DOUBLE, BYTES_IN_INT};
+use crate::memory_manager_constants::*;
+use crate::tib_layout_constants::*;
+use crate::JikesRVM;
 
 /// This type represents a JikesRVM-level `ObjectReference`.
 ///

--- a/mmtk/src/reference_glue.rs
+++ b/mmtk/src/reference_glue.rs
@@ -2,7 +2,7 @@ use mmtk::util::opaque_pointer::*;
 use mmtk::util::ObjectReference;
 use mmtk::vm::ReferenceGlue;
 
-use JikesRVM;
+use crate::JikesRVM;
 
 use std::convert::TryInto;
 

--- a/mmtk/src/scan_boot_image.rs
+++ b/mmtk/src/scan_boot_image.rs
@@ -1,9 +1,10 @@
+use crate::entrypoint::*;
+use crate::java_size_constants::*;
 use crate::scanning::SLOTS_BUFFER_CAPACITY;
 use crate::unboxed_size_constants::*;
 use crate::JikesRVM;
 use crate::JikesRVMSlot;
-use entrypoint::*;
-use java_size_constants::*;
+use crate::JTOC_BASE;
 use mmtk::scheduler::*;
 use mmtk::util::conversions;
 use mmtk::util::Address;
@@ -12,7 +13,6 @@ use mmtk::vm::RootsWorkFactory;
 use mmtk::MMTK;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use JTOC_BASE;
 
 const FILTER: bool = true;
 

--- a/mmtk/src/scan_statics.rs
+++ b/mmtk/src/scan_statics.rs
@@ -2,11 +2,11 @@ use crate::jikesrvm_calls;
 use crate::scanning::SLOTS_BUFFER_CAPACITY;
 use crate::JikesRVM;
 use crate::JikesRVMSlot;
+use crate::JTOC_BASE;
 use mmtk::scheduler::*;
 use mmtk::util::opaque_pointer::*;
 use mmtk::vm::RootsWorkFactory;
 use mmtk::MMTK;
-use JTOC_BASE;
 
 #[cfg(target_pointer_width = "32")]
 const REF_SLOT_SIZE: usize = 1;

--- a/mmtk/src/scanning.rs
+++ b/mmtk/src/scanning.rs
@@ -7,14 +7,16 @@ use crate::object_model::JikesObj;
 use mmtk::vm::ObjectTracer;
 use mmtk::vm::ObjectTracerContext;
 // use crate::scan_boot_image::ScanBootImageRoots;
+use crate::active_plan::VMActivePlan;
+use crate::entrypoint::*;
+use crate::java_header_constants::*;
+use crate::memory_manager_constants::*;
 use crate::scan_statics::ScanStaticRoots;
 use crate::unboxed_size_constants::LOG_BYTES_IN_ADDRESS;
+use crate::JikesRVM;
 use crate::JikesRVMSlot;
+use crate::JTOC_BASE;
 use crate::SINGLETON;
-use active_plan::VMActivePlan;
-use entrypoint::*;
-use java_header_constants::*;
-use memory_manager_constants::*;
 use mmtk::memory_manager;
 use mmtk::scheduler::*;
 use mmtk::util::opaque_pointer::*;
@@ -26,8 +28,6 @@ use mmtk::vm::SlotVisitor;
 use mmtk::MMTK;
 use mmtk::*;
 use std::mem;
-use JikesRVM;
-use JTOC_BASE;
 
 #[derive(Default)]
 pub struct VMScanning {}


### PR DESCRIPTION
Notably, imports relative to the current crate starts with `crate::`.

Also changed some macro definitions to use `$crate::` to refer to identifiers in the current crate.